### PR TITLE
#62: Support for Qualifacts PHQ-9

### DIFF
--- a/src/app/core/lib/condition/condition.ts
+++ b/src/app/core/lib/condition/condition.ts
@@ -6,7 +6,7 @@ import { fhirclient } from 'fhirclient/lib/types';
 
 import { MccCondition, MccConditionList, MccConditionSummary } from '../../types/mcc-types';
 import log from '../../utils/loglevel';
-import { fhirOptions, notFoundResponse, resourcesFrom, resourcesFromObject, getSupplementalDataClient } from '../../utils/fhir';
+import { fhirOptions, notFoundResponse, resourcesFrom, resourcesFromObject, getSupplementalDataClient, stripTrailingSlash } from '../../utils/fhir';
 import {
   transformToConditionSummary,
 } from './condition.util';
@@ -77,12 +77,13 @@ export const getSupplementalConditions = async (launchURL: string, sdsClient: Cl
       const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
       const urlSet = new Set();
 
-      urlSet.add(launchURL)
+      urlSet.add(stripTrailingSlash(launchURL))
       // Loop through second set of linkages
       for (const entry2 of linkages.entry) {
         for (const item2 of entry2.resource.item) {
-          if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-            urlSet.add(item2.resource.extension[0].valueUrl);
+          const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+          if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+            urlSet.add(alternateUrl);
             // Prepare FHIR request headers
             const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;
             const fhirHeaders = {
@@ -91,12 +92,12 @@ export const getSupplementalConditions = async (launchURL: string, sdsClient: Cl
             fhirHeaderRequestOption.headers = fhirHeaders;
             fhirHeaderRequestOption.url = 'Condition?subject=' + item2.resource.reference;
 
-            // Fetch third-party goals
+            // Fetch third-party conditions
             const response: fhirclient.JsonArray = await sdsClient.request(fhirHeaderRequestOption, fhirOptions);
 
-            // Process third-party goals
-            const thirdPartyGoals: Condition[] = resourcesFrom(response) as Condition[];
-            thirdPartyGoals.forEach(condition => {
+            // Process third-party conditions
+            const thirdPartyConditions: Condition[] = resourcesFrom(response) as Condition[];
+            thirdPartyConditions.forEach(condition => {
               condition.recorder = {
                 display: item2.resource.extension[0].valueUrl
               };

--- a/src/app/core/lib/encounter/encounter.ts
+++ b/src/app/core/lib/encounter/encounter.ts
@@ -5,7 +5,7 @@ import Client from 'fhirclient/lib/Client';
 
 import { MccDocumentReference, MccEncounter } from '../../types/mcc-types';
 import log from '../../utils/loglevel';
-import { fhirOptions, resourcesFrom, getSupplementalDataClient } from '../../utils/fhir';
+import { fhirOptions, resourcesFrom, getSupplementalDataClient, stripTrailingSlash } from '../../utils/fhir';
 import { buildRelativeDate } from '../../utils/date.utils';
 
 import {
@@ -216,12 +216,13 @@ const getSupplementalEncounters = async (launchURL: string, sdsClient: Client): 
       const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
       const urlSet = new Set();
 
-      urlSet.add(launchURL)
+      urlSet.add(stripTrailingSlash(launchURL))
       // Loop through second set of linkages
       for (const entry2 of linkages.entry) {
         for (const item2 of entry2.resource.item) {
-          if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-            urlSet.add(item2.resource.extension[0].valueUrl);
+          const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+          if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+            urlSet.add(alternateUrl);
             // Prepare FHIR request headers
             const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;
             const fhirHeaders = {
@@ -254,12 +255,13 @@ export const getSupplementalDocumentReferences = async (launchURL: string, sdsCl
       const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
       const urlSet = new Set();
 
-      urlSet.add(launchURL)
+      urlSet.add(stripTrailingSlash(launchURL))
       // Loop through second set of linkages
       for (const entry2 of linkages.entry) {
         for (const item2 of entry2.resource.item) {
-          if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-            urlSet.add(item2.resource.extension[0].valueUrl);
+          const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+          if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+            urlSet.add(alternateUrl);
             // Prepare FHIR request headers
             const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;
             const fhirHeaders = {

--- a/src/app/core/lib/goal/goal.ts
+++ b/src/app/core/lib/goal/goal.ts
@@ -7,7 +7,7 @@ import { fhirclient } from 'fhirclient/lib/types';
 
 import { MccGoal, MccGoalList, MccGoalSummary } from '../../types/mcc-types';
 import log from '../../utils/loglevel';
-import { fhirOptions, resourcesFrom, resourcesFromObject, notFoundResponse, getSupplementalDataClient} from '../../utils/fhir';
+import { fhirOptions, resourcesFrom, resourcesFromObject, notFoundResponse, getSupplementalDataClient, stripTrailingSlash} from '../../utils/fhir';
 
 import {
   transformToMccGoalSummary,
@@ -41,14 +41,14 @@ export const getSupplementalData = async (launchURL: string, sdsClient: Client):
   try {
 
     const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
-    console.log("patientId +linkages " + JSON.stringify(linkages));
     const urlSet = new Set();
-    urlSet.add(launchURL)
+    urlSet.add(stripTrailingSlash(launchURL))
     // Loop through second set of linkages
     for (const entry2 of linkages.entry) {
       for (const item2 of entry2.resource.item) {
-        if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-          urlSet.add(item2.resource.extension[0].valueUrl);
+        const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+        if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+          urlSet.add(alternateUrl);
 
           // Prepare FHIR request headers
           const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;

--- a/src/app/core/lib/medication-request/medication-request.ts
+++ b/src/app/core/lib/medication-request/medication-request.ts
@@ -11,7 +11,7 @@ import { getConditionFromUrl } from '../careplan';
 import { getConceptDisplayString } from '../goal/goal.util';
 import { convertNoteToString } from '../observation/observation.util';
 import { displayDate } from '../../utils/date.utils';
-import { fhirOptions, notFoundResponse, resourcesFrom, resourcesFromObject, getSupplementalDataClient} from '../../utils/fhir';
+import { fhirOptions, notFoundResponse, resourcesFrom, resourcesFromObject, getSupplementalDataClient, stripTrailingSlash} from '../../utils/fhir';
 import {MedicationFlag, RxClassSummary} from "../../../rxnorm/rxnormService";
 import MedicationFlagConfig from "../../../rxnorm/medicationFlagConfig.json";
 
@@ -38,12 +38,13 @@ const getSupplementalData = async (launchURL: string, sdsClient: Client): Promis
 
     const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
     const urlSet = new Set();
-    urlSet.add(launchURL);
+    urlSet.add(stripTrailingSlash(launchURL));
     // Loop through second set of linkages
     for (const entry2 of linkages.entry) {
       for (const item2 of entry2.resource.item) {
-        if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-          urlSet.add(item2.resource.extension[0].valueUrl);
+        const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+        if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+          urlSet.add(alternateUrl);
 
           // Prepare FHIR request headers
           const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;

--- a/src/app/core/lib/questionnaire-response/questionnaire-metadata.ts
+++ b/src/app/core/lib/questionnaire-response/questionnaire-metadata.ts
@@ -1,1133 +1,59 @@
 import { Questionnaire } from 'fhir/r4';
 
 export interface QuestionnaireMetadata {
-    id: string; // An internal identifier for the questionnaire. Edit environment.ts to configure which ids display.
+    id: string; // An internal identifier for the questionnaire. Edit environment.ts to configure which ids display. More than one key can map to the same id.
     display: string, // The label of the questionnaire to display to users.
-    url: string, // The url of the questionnaire. This is what the QuestionnaireResponse will reference in the questionnaire field.
     isScored: boolean, // Whether this questionnaire has a score question that should be pulled out and displayed in the UI.
     canBeCharted: boolean, // Whether this questionnaire has numeric scores that can be charted
-    definition: Questionnaire // The full FHIR Questionnaire resource that defines the questionnaire structure, questions, and scoring (if applicable).
+    definition: Questionnaire[] // The full FHIR Questionnaire resources that define the questionnaire structure, questions, and scoring. There can be multiple definitions. Survey Observations are converted to the first one.
 }
 
 export const questionnaireMetadata: QuestionnaireMetadata[] = [
     {
         "id": "PHQ-9",
         "display": "PHQ-9",
-        "url": "http://ohsu.edu/fhir/Questionnaire/PHQ-9",
         "isScored": true,
         "canBeCharted": true,
         "definition":
-        {
-            "resourceType": "Questionnaire",
-            "id": "44249-1",
-            "meta": {
-                "versionId": "1",
-                "lastUpdated": "2025-03-03T02:09:23.000-05:00",
-                "source": "#A9ftYtknikFekkjR",
-                "profile": [
-                    "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
-                ],
-                "tag": [
-                    {
-                        "code": "lformsVersion: 36.3.3"
-                    }
-                ]
-            },
-            "url": "http://ohsu.edu/fhir/Questionnaire/PHQ-9",
-            "title": "PHQ-9 quick depression assessment panel [Reported.PHQ]",
-            "status": "draft",
-            "copyright": "Copyright © Pfizer Inc. All rights reserved. Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc. No permission required to reproduce, translate, display or distribute.",
-            "code": [
+            [
                 {
-                    "system": "http://loinc.org",
-                    "code": "44249-1",
-                    "display": "PHQ-9 quick depression assessment panel [Reported.PHQ]"
-                }
-            ],
-            "item": [
-                {
-                    "linkId": "phq9",
+                    "resourceType": "Questionnaire",
+                    "id": "44249-1",
+                    "meta": {
+                        "versionId": "1",
+                        "lastUpdated": "2025-03-03T02:09:23.000-05:00",
+                        "source": "#A9ftYtknikFekkjR",
+                        "profile": [
+                            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+                        ],
+                        "tag": [
+                            {
+                                "code": "lformsVersion: 36.3.3"
+                            }
+                        ]
+                    },
+                    "url": "http://ohsu.edu/fhir/Questionnaire/PHQ-9",
+                    "title": "PHQ-9 quick depression assessment panel [Reported.PHQ]",
+                    "status": "draft",
+                    "copyright": "Copyright © Pfizer Inc. All rights reserved. Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc. No permission required to reproduce, translate, display or distribute.",
                     "code": [
                         {
-                            "code": "no-code",
-                            "display": "No code"
+                            "system": "http://loinc.org",
+                            "code": "44249-1",
+                            "display": "PHQ-9 quick depression assessment panel [Reported.PHQ]"
                         }
                     ],
-                    "text": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
-                    "type": "group",
                     "item": [
                         {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44250-9",
+                            "linkId": "phq9",
                             "code": [
                                 {
-                                    "system": "http://loinc.org",
-                                    "code": "44250-9",
-                                    "display": "Little interest or pleasure in doing things"
+                                    "code": "no-code",
+                                    "display": "No code"
                                 }
                             ],
-                            "text": "Little interest or pleasure in doing things",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44255-8",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44255-8",
-                                    "display": "Feeling down, depressed, or hopeless"
-                                }
-                            ],
-                            "text": "Feeling down, depressed, or hopeless",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44259-0",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44259-0",
-                                    "display": "Trouble falling or staying asleep, or sleeping too much"
-                                }
-                            ],
-                            "text": "Trouble falling or staying asleep, or sleeping too much",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44254-1",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44254-1",
-                                    "display": "Feeling tired or having little energy"
-                                }
-                            ],
-                            "text": "Feeling tired or having little energy",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44251-7",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44251-7",
-                                    "display": "Poor appetite or overeating"
-                                }
-                            ],
-                            "text": "Poor appetite or overeating",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44258-2",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44258-2",
-                                    "display": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down"
-                                }
-                            ],
-                            "text": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44252-5",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44252-5",
-                                    "display": "Trouble concentrating on things, such as reading the newspaper or watching television"
-                                }
-                            ],
-                            "text": "Trouble concentrating on things, such as reading the newspaper or watching television",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44253-3",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44253-3",
-                                    "display": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual"
-                                }
-                            ],
-                            "text": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/44260-8",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44260-8",
-                                    "display": "Thoughts that you would be better off dead, or of hurting yourself in some way"
-                                }
-                            ],
-                            "text": "Thoughts that you would be better off dead, or of hurting yourself in some way",
-                            "type": "choice",
-                            "required": true,
-                            "answerOption": [
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "0"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 0
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6568-5",
-                                        "display": "Not at all"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "1"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 1
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6569-3",
-                                        "display": "Several days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "2"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 2
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6570-1",
-                                        "display": "More than half the days"
-                                    }
-                                },
-                                {
-                                    "extension": [
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
-                                            "valueString": "3"
-                                        },
-                                        {
-                                            "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-                                            "valueDecimal": 3
-                                        }
-                                    ],
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6571-9",
-                                        "display": "Nearly every day"
-                                    }
-                                }
-                            ]
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "display": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
-                                            }
-                                        ],
-                                        "text": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
-                                    }
-                                },
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
-                                    "valueCoding": {
-                                        "code": "care-plan-score",
-                                        "display": "{score}"
-                                    }
-                                },
-                                {
-                                    "url": "range-score-interpretation",
-                                    "extension": [
-                                        {
-                                            "url": "range",
-                                            "valueRange": {
-                                                "low": {
-                                                    "value": 0
-                                                },
-                                                "high": {
-                                                    "value": 4
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "url": "interpretation",
-                                            "valueString": "Minimal"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "url": "range-score-interpretation",
-                                    "extension": [
-                                        {
-                                            "url": "range",
-                                            "valueRange": {
-                                                "low": {
-                                                    "value": 5
-                                                },
-                                                "high": {
-                                                    "value": 9
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "url": "interpretation",
-                                            "valueString": "Mild"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "url": "range-score-interpretation",
-                                    "extension": [
-                                        {
-                                            "url": "range",
-                                            "valueRange": {
-                                                "low": {
-                                                    "value": 10
-                                                },
-                                                "high": {
-                                                    "value": 14
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "url": "interpretation",
-                                            "valueString": "Moderate"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "url": "range-score-interpretation",
-                                    "extension": [
-                                        {
-                                            "url": "range",
-                                            "valueRange": {
-                                                "low": {
-                                                    "value": 15
-                                                },
-                                                "high": {
-                                                    "value": 19
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "url": "interpretation",
-                                            "valueString": "Moderately Severe"
-                                        }
-                                    ]
-                                },
-                                {
-                                    "url": "range-score-interpretation",
-                                    "extension": [
-                                        {
-                                            "url": "range",
-                                            "valueRange": {
-                                                "low": {
-                                                    "value": 20
-                                                },
-                                                "high": {
-                                                    "value": 27
-                                                }
-                                            }
-                                        },
-                                        {
-                                            "url": "interpretation",
-                                            "valueString": "Severe"
-                                        }
-                                    ]
-                                }
-                            ],
-                            "linkId": "/44261-6",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "44261-6",
-                                    "display": "Patient health questionnaire 9 item total score"
-                                }
-                            ],
-                            "text": "Patient health questionnaire 9 item total score",
-                            "type": "quantity",
-                            "required": false
-                        },
-                        {
-                            "extension": [
-                                {
-                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
-                                    "valueCodeableConcept": {
-                                        "coding": [
-                                            {
-                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                "code": "drop-down",
-                                                "display": "Drop down"
-                                            }
-                                        ],
-                                        "text": "Drop down"
-                                    }
-                                }
-                            ],
-                            "linkId": "/69722-7",
-                            "code": [
-                                {
-                                    "system": "http://loinc.org",
-                                    "code": "69722-7",
-                                    "display": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
-                                }
-                            ],
-                            "text": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?",
-                            "type": "choice",
-                            "required": false,
-                            "answerOption": [
-                                {
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6572-7",
-                                        "display": "Not difficult at all"
-                                    }
-                                },
-                                {
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6573-5",
-                                        "display": "Somewhat difficult"
-                                    }
-                                },
-                                {
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6575-0",
-                                        "display": "Very difficult"
-                                    }
-                                },
-                                {
-                                    "valueCoding": {
-                                        "system": "http://loinc.org",
-                                        "code": "LA6574-3",
-                                        "display": "Extremely difficult"
-                                    }
-                                }
-                            ],
+                            "text": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
+                            "type": "group",
                             "item": [
                                 {
                                     "extension": [
@@ -1137,32 +63,2163 @@ export const questionnaireMetadata: QuestionnaireMetadata[] = [
                                                 "coding": [
                                                     {
                                                         "system": "http://hl7.org/fhir/questionnaire-item-control",
-                                                        "code": "help",
-                                                        "display": "Help-Button"
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
                                                     }
                                                 ],
-                                                "text": "Help-Button"
+                                                "text": "Drop down"
                                             }
                                         }
                                     ],
-                                    "linkId": "/69722-7-help",
-                                    "text": "If you checked off any problems on this questionnaire",
-                                    "type": "display"
+                                    "linkId": "/44250-9",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44250-9",
+                                            "display": "Little interest or pleasure in doing things"
+                                        }
+                                    ],
+                                    "text": "Little interest or pleasure in doing things",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44255-8",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44255-8",
+                                            "display": "Feeling down, depressed, or hopeless"
+                                        }
+                                    ],
+                                    "text": "Feeling down, depressed, or hopeless",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44259-0",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44259-0",
+                                            "display": "Trouble falling or staying asleep, or sleeping too much"
+                                        }
+                                    ],
+                                    "text": "Trouble falling or staying asleep, or sleeping too much",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44254-1",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44254-1",
+                                            "display": "Feeling tired or having little energy"
+                                        }
+                                    ],
+                                    "text": "Feeling tired or having little energy",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44251-7",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44251-7",
+                                            "display": "Poor appetite or overeating"
+                                        }
+                                    ],
+                                    "text": "Poor appetite or overeating",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44258-2",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44258-2",
+                                            "display": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down"
+                                        }
+                                    ],
+                                    "text": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44252-5",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44252-5",
+                                            "display": "Trouble concentrating on things, such as reading the newspaper or watching television"
+                                        }
+                                    ],
+                                    "text": "Trouble concentrating on things, such as reading the newspaper or watching television",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44253-3",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44253-3",
+                                            "display": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual"
+                                        }
+                                    ],
+                                    "text": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/44260-8",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44260-8",
+                                            "display": "Thoughts that you would be better off dead, or of hurting yourself in some way"
+                                        }
+                                    ],
+                                    "text": "Thoughts that you would be better off dead, or of hurting yourself in some way",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueDecimal": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "display": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
+                                                    }
+                                                ],
+                                                "text": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
+                                            }
+                                        },
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                                            "valueCoding": {
+                                                "code": "care-plan-score",
+                                                "display": "{score}"
+                                            }
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 0
+                                                        },
+                                                        "high": {
+                                                            "value": 4
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Minimal"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 5
+                                                        },
+                                                        "high": {
+                                                            "value": 9
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Mild"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 10
+                                                        },
+                                                        "high": {
+                                                            "value": 14
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Moderate"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 15
+                                                        },
+                                                        "high": {
+                                                            "value": 19
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Moderately Severe"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 20
+                                                        },
+                                                        "high": {
+                                                            "value": 27
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Severe"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "linkId": "/44261-6",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44261-6",
+                                            "display": "Patient health questionnaire 9 item total score"
+                                        }
+                                    ],
+                                    "text": "Patient health questionnaire 9 item total score",
+                                    "type": "quantity",
+                                    "required": false
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "/69722-7",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "69722-7",
+                                            "display": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?"
+                                        }
+                                    ],
+                                    "text": "How difficult have these problems made it for you to do your work, take care of things at home, or get along with other people?",
+                                    "type": "choice",
+                                    "required": false,
+                                    "answerOption": [
+                                        {
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6572-7",
+                                                "display": "Not difficult at all"
+                                            }
+                                        },
+                                        {
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6573-5",
+                                                "display": "Somewhat difficult"
+                                            }
+                                        },
+                                        {
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6575-0",
+                                                "display": "Very difficult"
+                                            }
+                                        },
+                                        {
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6574-3",
+                                                "display": "Extremely difficult"
+                                            }
+                                        }
+                                    ],
+                                    "item": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                                    "valueCodeableConcept": {
+                                                        "coding": [
+                                                            {
+                                                                "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                                "code": "help",
+                                                                "display": "Help-Button"
+                                                            }
+                                                        ],
+                                                        "text": "Help-Button"
+                                                    }
+                                                }
+                                            ],
+                                            "linkId": "/69722-7-help",
+                                            "text": "If you checked off any problems on this questionnaire",
+                                            "type": "display"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "resourceType": "Questionnaire",
+                    "id": "44249-1",
+                    "meta": {
+                        "versionId": "1",
+                        "lastUpdated": "2025-03-03T02:09:23.000-05:00",
+                        "source": "#A9ftYtknikFekkjR",
+                        "profile": [
+                            "http://hl7.org/fhir/4.0/StructureDefinition/Questionnaire"
+                        ],
+                        "tag": [
+                            {
+                                "code": "lformsVersion: 36.3.3"
+                            }
+                        ]
+                    },
+                    "url": "http://ohsu.edu/fhir/Questionnaire/PHQ-9-qualifacts",
+                    "title": "PHQ-9 quick depression assessment panel [Reported.PHQ]",
+                    "status": "draft",
+                    "copyright": "Copyright © Pfizer Inc. All rights reserved. Developed by Drs. Robert L. Spitzer, Janet B.W. Williams, Kurt Kroenke and colleagues, with an educational grant from Pfizer Inc. No permission required to reproduce, translate, display or distribute.",
+                    "code": [
+                        {
+                            "system": "http://loinc.org",
+                            "code": "44249-1",
+                            "display": "PHQ-9 quick depression assessment panel [Reported.PHQ]"
+                        }
+                    ],
+                    "item": [
+                        {
+                            "linkId": "phq9",
+                            "code": [
+                                {
+                                    "code": "no-code",
+                                    "display": "No code"
+                                }
+                            ],
+                            "text": "Over the last 2 weeks, how often have you been bothered by any of the following problems?",
+                            "type": "group",
+                            "item": [
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "1",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44250-9",
+                                            "display": "Little interest or pleasure in doing things"
+                                        }
+                                    ],
+                                    "text": "Little interest or pleasure in doing things",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "2",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44255-8",
+                                            "display": "Feeling down, depressed, or hopeless"
+                                        }
+                                    ],
+                                    "text": "Feeling down, depressed, or hopeless",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "3",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44259-0",
+                                            "display": "Trouble falling or staying asleep, or sleeping too much"
+                                        }
+                                    ],
+                                    "text": "Trouble falling or staying asleep, or sleeping too much",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "4",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44254-1",
+                                            "display": "Feeling tired or having little energy"
+                                        }
+                                    ],
+                                    "text": "Feeling tired or having little energy",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "5",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44251-7",
+                                            "display": "Poor appetite or overeating"
+                                        }
+                                    ],
+                                    "text": "Poor appetite or overeating",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "6",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44258-2",
+                                            "display": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down"
+                                        }
+                                    ],
+                                    "text": "Feeling bad about yourself-or that you are a failure or have let yourself or your family down",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "7",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44252-5",
+                                            "display": "Trouble concentrating on things, such as reading the newspaper or watching television"
+                                        }
+                                    ],
+                                    "text": "Trouble concentrating on things, such as reading the newspaper or watching television",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "8",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44253-3",
+                                            "display": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual"
+                                        }
+                                    ],
+                                    "text": "Moving or speaking so slowly that other people could have noticed. Or the opposite – being so fidgety or restless that you were moving around a lot more than usual",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-itemControl",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "system": "http://hl7.org/fhir/questionnaire-item-control",
+                                                        "code": "drop-down",
+                                                        "display": "Drop down"
+                                                    }
+                                                ],
+                                                "text": "Drop down"
+                                            }
+                                        }
+                                    ],
+                                    "linkId": "9",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44260-8",
+                                            "display": "Thoughts that you would be better off dead, or of hurting yourself in some way"
+                                        }
+                                    ],
+                                    "text": "Thoughts that you would be better off dead, or of hurting yourself in some way",
+                                    "type": "choice",
+                                    "required": true,
+                                    "answerOption": [
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "0"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 0
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6568-5",
+                                                "display": "Not at all"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "1"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 1
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6569-3",
+                                                "display": "Several days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "2"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 2
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6570-1",
+                                                "display": "More than half the days"
+                                            }
+                                        },
+                                        {
+                                            "extension": [
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-optionPrefix",
+                                                    "valueString": "3"
+                                                },
+                                                {
+                                                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                                                    "valueInteger": 3
+                                                }
+                                            ],
+                                            "valueCoding": {
+                                                "system": "http://loinc.org",
+                                                "code": "LA6571-9",
+                                                "display": "Nearly every day"
+                                            }
+                                        }
+                                    ]
+                                },
+                                {
+                                    "extension": [
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-displayCategory",
+                                            "valueCodeableConcept": {
+                                                "coding": [
+                                                    {
+                                                        "display": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
+                                                    }
+                                                ],
+                                                "text": "The PHQ-9 is the standard (and most commonly used) depression measure, and it ranges from 0-27 Scoring: Add up all checked boxes on PHQ-9. For every check: Not at all = 0; Several days = 1; More than half the days = 2; Nearly every day = 3 (the scores are the codes that appear in the answer list for each of the PHQ-9 problem panel terms). Interpretation: 1-4 = Minimal depression; 5-9 = Mild depression; 10-14 = Moderate depression; 15-19 = Moderately severe depression; 20-27 = Severed depression."
+                                            }
+                                        },
+                                        {
+                                            "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit",
+                                            "valueCoding": {
+                                                "code": "care-plan-score",
+                                                "display": "{score}"
+                                            }
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 0
+                                                        },
+                                                        "high": {
+                                                            "value": 4
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Minimal"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 5
+                                                        },
+                                                        "high": {
+                                                            "value": 9
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Mild"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 10
+                                                        },
+                                                        "high": {
+                                                            "value": 14
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Moderate"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 15
+                                                        },
+                                                        "high": {
+                                                            "value": 19
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Moderately Severe"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "url": "range-score-interpretation",
+                                            "extension": [
+                                                {
+                                                    "url": "range",
+                                                    "valueRange": {
+                                                        "low": {
+                                                            "value": 20
+                                                        },
+                                                        "high": {
+                                                            "value": 27
+                                                        }
+                                                    }
+                                                },
+                                                {
+                                                    "url": "interpretation",
+                                                    "valueString": "Severe"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "linkId": "total-score",
+                                    "code": [
+                                        {
+                                            "system": "http://loinc.org",
+                                            "code": "44261-6",
+                                            "display": "Patient health questionnaire 9 item total score"
+                                        }
+                                    ],
+                                    "text": "Patient health questionnaire 9 item total score",
+                                    "type": "quantity",
+                                    "required": false
                                 }
                             ]
                         }
                     ]
                 }
             ]
-        }
     },
     {
         "id": "GAD-7",
         "display": "GAD-7",
-        "url": "http://ohsu.edu/fhir/Questionnaire/GAD-7",
         "isScored": true,
         "canBeCharted": true,
-        "definition": {
+        "definition": [{
             "resourceType": "Questionnaire",
             "id": "69737-5",
             "url": "http://ohsu.edu/fhir/Questionnaire/GAD-7",
@@ -1880,15 +2937,14 @@ export const questionnaireMetadata: QuestionnaireMetadata[] = [
                     ]
                 }
             ]
-        }
+        }]
     },
     {
         "id": "PROMIS-29",
         "display": "PROMIS-29",
-        "url": "http://loinc.org/q/62337-1",
         "isScored": false,
         "canBeCharted": false,
-        "definition": {
+        "definition": [{
             "resourceType": "Questionnaire",
             "id": "62337-1",
             "meta": {
@@ -3526,15 +4582,14 @@ export const questionnaireMetadata: QuestionnaireMetadata[] = [
                     ]
                 }
             ]
-        }
+        }]
     },
     {
         "id": "C-SSRS",
         "display": "C-SSRS",
-        "url": "http://ohsu.edu/fhir/Questionnaire/C-SSRS",
         "isScored": true,
         "canBeCharted": false,
-        "definition": {
+        "definition": [{
             "resourceType": "Questionnaire",
             "id": "93373-9",
             "url": "http://ohsu.edu/fhir/Questionnaire/C-SSRS",
@@ -3893,6 +4948,6 @@ export const questionnaireMetadata: QuestionnaireMetadata[] = [
                     ]
                 }
             ]
-        }
+        }]
     }
 ];

--- a/src/app/core/lib/questionnaire-response/questionnaire-response.ts
+++ b/src/app/core/lib/questionnaire-response/questionnaire-response.ts
@@ -5,9 +5,9 @@ import { fhirclient } from 'fhirclient/lib/types';
 
 import { EcpAssessmentSummary } from '../../types/mcc-types';
 import {getObservationsByCategory} from '../observation/observation';
-import { fhirOptions, resourcesFrom, getSupplementalDataClient} from '../../utils/fhir';
+import { fhirOptions, resourcesFrom, getSupplementalDataClient, stripTrailingSlash} from '../../utils/fhir';
 import {
-    filterQuestionnaireResponsesByConfigured, getQuestionnaireResponsesFromObservations, transformToAssessmentSummary
+    filterQuestionnaireResponsesByConfigured, getQuestionnaireResponsesFromObservations, groupQuestionnaireResponsesById, transformToAssessmentSummary
 } from './questionnaire-response.util';
 
 const getSupplementalSurveyObservations = async (launchURL: string, sdsClient: Client): Promise<Observation[]> => {
@@ -18,12 +18,13 @@ const getSupplementalSurveyObservations = async (launchURL: string, sdsClient: C
       const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
       const urlSet = new Set();
 
-      urlSet.add(launchURL)
+      urlSet.add(stripTrailingSlash(launchURL))
       // Loop through second set of linkages
       for (const entry2 of linkages.entry) {
         for (const item2 of entry2.resource.item) {
-          if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-            urlSet.add(item2.resource.extension[0].valueUrl);
+          const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+          if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+            urlSet.add(alternateUrl);
             // Prepare FHIR request headers
             const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;
             const fhirHeaders = {
@@ -61,12 +62,13 @@ const getSupplementalQuestionnaireResponses = async (launchURL: string, sdsClien
       const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
       const urlSet = new Set();
 
-      urlSet.add(launchURL)
+      urlSet.add(stripTrailingSlash(launchURL))
       // Loop through second set of linkages
       for (const entry2 of linkages.entry) {
         for (const item2 of entry2.resource.item) {
-          if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-            urlSet.add(item2.resource.extension[0].valueUrl);
+          const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+          if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+            urlSet.add(alternateUrl);
             // Prepare FHIR request headers
             const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;
             const fhirHeaders = {
@@ -75,7 +77,7 @@ const getSupplementalQuestionnaireResponses = async (launchURL: string, sdsClien
             fhirHeaderRequestOption.headers = fhirHeaders;
             fhirHeaderRequestOption.url = 'QuestionnaireResponse?subject=' + item2.resource.reference;
 
-            // Fetch third-party goals
+            // Fetch third-party
             const response: fhirclient.JsonArray = await sdsClient.request(fhirHeaderRequestOption, fhirOptions);
 
             // Process third-party questionnaire responses
@@ -122,49 +124,66 @@ export const getAssessments = async (sdsURL: string, authURL: string, sdsScope: 
     const surveyObservations = await getObservationsByCategory('survey');
     const observationalSurveyResponses = getQuestionnaireResponsesFromObservations(surveyObservations, configuredQuestionnaires);
 
+    let allResponses = [...questionnaireResponses, ...observationalSurveyResponses];
+    allResponses.forEach(resource => {
+        resource.meta = {
+            source: "Primary"
+        };
+    });
+
     let sdsClient = await getSupplementalDataClient(client, sdsURL, authURL, sdsScope);
 
     let sdsQuestionnaireResponses: QuestionnaireResponse[] = [];
     if (sdsClient) {
 
-        // See if there are 3rd party survey observations available from the SDS
-        const thirdPartySurveyObservations = await getSupplementalSurveyObservations(client.state.serverUrl, sdsClient);
-        const sdsSurveyResponses = getQuestionnaireResponsesFromObservations(thirdPartySurveyObservations, configuredQuestionnaires);
-        observationalSurveyResponses.push(...sdsSurveyResponses);
-
+        // Look for QuestionnaireResponses in the default SDS partition (written by MyCarePlanner)
         const sdsQuestionnaireResponse: fhirclient.JsonArray = await sdsClient.patient.request('QuestionnaireResponse', fhirOptions);
-
         const sdsQuestionnaireResponseArray: QuestionnaireResponse[] = resourcesFrom(
             sdsQuestionnaireResponse
         ) as QuestionnaireResponse[];
-
-        // #28 - Replace the meta tag on resources from the SDS
         sdsQuestionnaireResponseArray.forEach(resource => {
             resource.meta = {
                 source: "MyCarePlanner"
             };
         });
-        
-        sdsQuestionnaireResponses = filterQuestionnaireResponsesByConfigured(sdsQuestionnaireResponseArray as QuestionnaireResponse[], configuredQuestionnaires);
-        questionnaireResponses.push(...sdsQuestionnaireResponses);
 
+        // Look for 3rd party survey observations in the SDS
+        const thirdPartySurveyObservations = await getSupplementalSurveyObservations(client.state.serverUrl, sdsClient);
+        const thirdPartyObservationalSurveyResponses = getQuestionnaireResponsesFromObservations(thirdPartySurveyObservations, configuredQuestionnaires);
+        thirdPartyObservationalSurveyResponses.forEach(resource => {
+            resource.meta = {
+                source: "External"
+            };
+        });
+
+        // Look for third party QuestionnaireResponses in the SDS
         const thirdPartyQuestionnaireResponses = await getSupplementalQuestionnaireResponses(client.state.serverUrl, sdsClient);
-        questionnaireResponses.push(...thirdPartyQuestionnaireResponses);
+        thirdPartyQuestionnaireResponses.forEach(resource => {
+            resource.meta = {
+                source: "External"
+            };
+        });
+
+        allResponses.push(...thirdPartyObservationalSurveyResponses, ...sdsQuestionnaireResponses, ...thirdPartyQuestionnaireResponses);
     }
 
-    const allResponses = [...observationalSurveyResponses, ...questionnaireResponses];
+    // Look for the identifier that indicates this is a Qualifacts survey and set the questionnaire field to the correct URL for the questionnaire.
+    allResponses.forEach(response => {
+      if (response.identifier?.value?.includes('PHQ9')) {
+        response.questionnaire = 'http://ohsu.edu/fhir/Questionnaire/PHQ-9-qualifacts';
+      }
+    });
+    const configuredResponses = filterQuestionnaireResponsesByConfigured(allResponses, configuredQuestionnaires);  
 
-    const groupedByUrl = allResponses.reduce((acc, curr) => {
-        const key = (curr as QuestionnaireResponse).questionnaire;
-        if (!acc[key]) acc[key] = [];
-        acc[key].push(curr);
-        return acc;
-    }, {} as Record<string, Resource[]>);
+    const groupedById = groupQuestionnaireResponsesById(configuredResponses);
 
     // Pass each resource array to the transformToAssessmentSummary function
-    Object.values(groupedByUrl).forEach((resourcesToTransform: QuestionnaireResponse[]) => {
+    Object.values(groupedById).forEach((resourcesToTransform: QuestionnaireResponse[]) => {
         if (resourcesToTransform.length > 0) {
-            assessments.push(transformToAssessmentSummary(resourcesToTransform));
+            const assessmentSummary = transformToAssessmentSummary(resourcesToTransform);
+            if (assessmentSummary) {
+                assessments.push(assessmentSummary);
+            }
         }
     });
 

--- a/src/app/core/lib/questionnaire-response/questionnaire-response.util.ts
+++ b/src/app/core/lib/questionnaire-response/questionnaire-response.util.ts
@@ -3,12 +3,41 @@ import { EcpAssessment, EcpAssessmentSummary, EcpScore, MCCAssessmentResponseIte
 import { QuestionnaireMetadata, questionnaireMetadata } from './questionnaire-metadata';
 import { displayDate } from '../../utils/date.utils';
 
+function getAnswer(item: QuestionnaireResponseItem): MCCAssessmentResponseItem {
+    return {
+        question: item.text ?? '',
+        answer: item.answer && item.answer.length > 0 ? extractAnswerValue(item.answer[0]) : ''
+    };
+}
+
+function extractAnswerValue(answer: QuestionnaireResponseItemAnswer): string {
+
+    return (
+        answer.valueCoding?.display ??
+        answer.valueString ??
+        answer.valueInteger?.toString() ??
+        answer.valueDecimal?.toString() ??
+        (answer.valueBoolean !== undefined ? (answer.valueBoolean ? 'True' : 'False') : undefined) ??
+        answer.valueDate ??
+        answer.valueDateTime ??
+        answer.valueTime ??
+        answer.valueQuantity?.value?.toString() ??
+        JSON.stringify(answer)
+    );
+}
+
+function getMetadataByDefinitionUrl(definitionUrl: string): QuestionnaireMetadata | undefined {
+    return questionnaireMetadata.find(metadata =>
+        metadata.definition.some(def => def.url === definitionUrl)
+    );
+}
+
 function isScoreQuestion(item: QuestionnaireItem) {
     return item?.extension?.some(
-    (ext) =>
-      ext.url === "http://hl7.org/fhir/StructureDefinition/questionnaire-unit" &&
-      ext.valueCoding?.code === "care-plan-score"
-  ) ?? false;
+        (ext) =>
+            ext.url === "http://hl7.org/fhir/StructureDefinition/questionnaire-unit" &&
+            ext.valueCoding?.code === "care-plan-score"
+    ) ?? false;
 }
 
 /**
@@ -17,19 +46,19 @@ function isScoreQuestion(item: QuestionnaireItem) {
  * @returns 
  */
 function findScoreItem(items: QuestionnaireItem[]): QuestionnaireItem | undefined {
-  for (const item of items) {
-    if (isScoreQuestion(item)) {
-      return item;
+    for (const item of items) {
+        if (isScoreQuestion(item)) {
+            return item;
+        }
+
+        // Recurse into nested items
+        if (item.item && item.item.length > 0) {
+            const found = findScoreItem(item.item);
+            if (found) return found;
+        }
     }
 
-    // Recurse into nested items
-    if (item.item && item.item.length > 0) {
-      const found = findScoreItem(item.item);
-      if (found) return found;
-    }
-  }
-
-  return undefined;
+    return undefined;
 }
 
 /**
@@ -39,31 +68,23 @@ function findScoreItem(items: QuestionnaireItem[]): QuestionnaireItem | undefine
  * @returns 
  */
 function findScoreValueByLinkId(items: QuestionnaireResponseItem[], targetLinkId: string): string | undefined {
-  for (const item of items) {
-    if (item.linkId === targetLinkId && item.answer && item.answer.length > 0) {
-      // Return the actual value (valueInteger, valueDecimal, etc.)
-      const answer = item.answer[0];
-      return extractAnswerValue(answer);
+    for (const item of items) {
+        if (item.linkId === targetLinkId && item.answer && item.answer.length > 0) {
+            // Return the actual value (valueInteger, valueDecimal, etc.)
+            const answer = item.answer[0];
+            return extractAnswerValue(answer);
+        }
+
+        // Recurse into nested items
+        if (item.item && item.item.length > 0) {
+            const result = findScoreValueByLinkId(item.item, targetLinkId);
+            if (result !== undefined) {
+                return result;
+            }
+        }
     }
 
-    // Recurse into nested items
-    if (item.item && item.item.length > 0) {
-      const result = findScoreValueByLinkId(item.item, targetLinkId);
-      if (result !== undefined) {
-        return result;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-function extractAnswerValue(answer: QuestionnaireResponseItemAnswer): string | undefined {
-  if ('valueInteger' in answer) return answer.valueInteger?.toString();
-  if ('valueDecimal' in answer) return answer.valueDecimal?.toString();
-  if ('valueQuantity' in answer) return answer.valueQuantity?.value?.toString();
-  if ('valueString' in answer) return answer.valueString;
-  return undefined;
+    return undefined;
 }
 
 function interpretScore(questionnaireDefinition: Questionnaire, score: number): string | undefined {
@@ -83,16 +104,14 @@ function interpretScore(questionnaireDefinition: Questionnaire, score: number): 
     return undefined;
 }
 
-export function getScore(response: QuestionnaireResponse, metadata: QuestionnaireMetadata): EcpScore | undefined {
-    const scoreItem = findScoreItem(metadata.definition.item || []);
+export function getScore(response: QuestionnaireResponse, questionnaireDefinition: Questionnaire): EcpScore | undefined {
+    const scoreItem = findScoreItem(questionnaireDefinition.item || []);
     if (scoreItem) {
         const scoreValue = findScoreValueByLinkId(response.item || [], scoreItem.linkId);
         if (scoreValue === undefined) return undefined;
-    
-
         return {
             value: scoreValue,
-            interpretation: !isNaN(parseFloat(scoreValue)) ? interpretScore(metadata.definition, parseFloat(scoreValue)) || null : null
+            interpretation: !isNaN(parseFloat(scoreValue)) ? interpretScore(questionnaireDefinition, parseFloat(scoreValue)) || null : null
         };
     }
     return undefined;
@@ -128,14 +147,15 @@ function collectMatchingItems(questionnaireItems: QuestionnaireItem[], members: 
                             system: coding.system,
                             code: coding.code,
                             display: coding.display
-                        }});
+                        }
+                    });
                 });
             } else if (observation.valueQuantity) {
-                responseItem.answer?.push({valueString: observation.valueQuantity.value?.toString()});
+                responseItem.answer?.push({ valueString: observation.valueQuantity.value?.toString() });
             } else if (observation.valueInteger) {
-                responseItem.answer?.push({valueString: observation.valueInteger?.toString()});
+                responseItem.answer?.push({ valueString: observation.valueInteger?.toString() });
             } else if (observation.valueString) {
-                responseItem.answer?.push({valueString: observation.valueString})
+                responseItem.answer?.push({ valueString: observation.valueString })
             }
             else {
                 console.warn(`Unsupported observation value type for observation with code ${code}: `, observation);
@@ -162,7 +182,7 @@ function convertObservations(questionnaireDef: Questionnaire, surveyObservations
     const questionnaireResponses: QuestionnaireResponse[] = [];
     const topLevelCode = questionnaireDef.code?.[0]?.code; // Assumes the first code in the questionnaireDef is the one we'll find in observations
     const topLevelObservations = surveyObservations.filter(o =>
-            o.code.coding?.some(e => e.code === topLevelCode)
+        o.code.coding?.some(e => e.code === topLevelCode)
     );
 
     if (topLevelObservations.length > 0) {
@@ -188,7 +208,7 @@ function convertObservations(questionnaireDef: Questionnaire, surveyObservations
 
             questionnaireResponse.item = responseItems;
 
-            questionnaireResponses.push(questionnaireResponse);    
+            questionnaireResponses.push(questionnaireResponse);
         }
     }
 
@@ -197,7 +217,10 @@ function convertObservations(questionnaireDef: Questionnaire, surveyObservations
 
 export function filterQuestionnaireResponsesByConfigured(questionnaireResponses: QuestionnaireResponse[], configuredQuestionnaires: string[]): QuestionnaireResponse[] {
     return questionnaireResponses.filter(qr => {
-        const metadata = questionnaireMetadata.find(metadata => metadata.url === qr.questionnaire);
+        if (!qr.questionnaire) {
+            return false;
+        }
+        const metadata = getMetadataByDefinitionUrl(qr.questionnaire);
         return metadata && configuredQuestionnaires.includes(metadata.id);
     });
 }
@@ -206,7 +229,7 @@ export function getQuestionnaireResponsesFromObservations(surveyObservations: Ob
     const questionnaireResponses: QuestionnaireResponse[] = [];
     
     // Filter to only configured questionnaires
-    const filteredQuestionnaireMetadata = configuredQuestionnaires.map(id => 
+    const filteredQuestionnaireMetadata = configuredQuestionnaires.map(id =>
         questionnaireMetadata.find(metadata => metadata.id === id)
     ).filter((metadata): metadata is QuestionnaireMetadata => metadata !== undefined);
 
@@ -214,16 +237,67 @@ export function getQuestionnaireResponsesFromObservations(surveyObservations: Ob
 
     // Iterate through each questionnaire definition
     for (const metadata of filteredQuestionnaireMetadata) {
-        const responses = convertObservations(metadata.definition, surveyObservations);
+        // The first definition in the array is the one used for survey observations
+        const responses = convertObservations(metadata.definition[0], surveyObservations);
         questionnaireResponses.push(...responses);
     }
 
     return questionnaireResponses;
 }
 
-export function transformToAssessmentSummary(resourcesToTransform: QuestionnaireResponse[]): EcpAssessmentSummary {
+export function groupQuestionnaireResponsesById(questionnaireResponses: QuestionnaireResponse[]): Record<string, QuestionnaireResponse[]> {
+    // First, create a lookup map from definition URL to metadata id
+    const definitionToMetadataId = new Map<string, string>();
+
+    questionnaireMetadata.forEach(metadata => {
+        metadata.definition.forEach(def => {
+            if (def.url) {
+                definitionToMetadataId.set(def.url, metadata.id);
+            }
+        });
+    });
+
+    // Then group responses using the metadata id
+    const groupedById = questionnaireResponses.reduce((acc, curr) => {
+        const response = curr as QuestionnaireResponse;
+        const definitionUrl = response?.questionnaire;
+
+        // Skip if no questionnaire URL
+        if (!definitionUrl) return acc;
+
+        // Look up which metadata this definition belongs to
+        const metadataId = definitionToMetadataId.get(definitionUrl);
+
+        if (!metadataId) {
+            console.warn(`No metadata found for questionnaire definition URL: ${definitionUrl}`);
+            return acc;
+        }
+
+        if (!acc[metadataId]) {
+            acc[metadataId] = [];
+        }
+        acc[metadataId].push(curr);
+        return acc;
+    }, {} as Record<string, QuestionnaireResponse[]>);
+    return groupedById;
+}
+
+export function transformToAssessmentSummary(resourcesToTransform: QuestionnaireResponse[]): EcpAssessmentSummary | null {
+     // Validate input
+    if (!resourcesToTransform || resourcesToTransform.length === 0) {
+        return null;
+    }
+
+    const firstQuestionnaire = resourcesToTransform[0]?.questionnaire;
+    if (!firstQuestionnaire) {
+        return null;
+    }
+
     // Get the metadata entry for the questionnaire
-    const metadata = questionnaireMetadata.find(metadata => metadata.url === resourcesToTransform[0].questionnaire);
+    const metadata = getMetadataByDefinitionUrl(firstQuestionnaire);
+    if (!metadata) {
+        return null;
+    }
     let assessmentSummary: EcpAssessmentSummary = {
         title: metadata.display,
         isScored: metadata.isScored,
@@ -232,11 +306,17 @@ export function transformToAssessmentSummary(resourcesToTransform: Questionnaire
     }
 
     resourcesToTransform.forEach((response: QuestionnaireResponse) => {
-        
+
+        if (!response.questionnaire || !response.item) return;
+
+        const questionnaireDefinition = metadata.definition.find(
+            def => def.url === response?.questionnaire
+        );
+
         const assessment: EcpAssessment = {
-            date: displayDate(response.authored),
-            source: response.meta?.source || undefined,
-            score: metadata.isScored ? getScore(response, metadata) : undefined,
+            date: displayDate(response.authored) || '',
+            source: response.meta?.source || '',
+            score: metadata.isScored && questionnaireDefinition ? getScore(response, questionnaireDefinition) : undefined,
             questions: []
         };
 
@@ -255,15 +335,6 @@ export function transformToAssessmentSummary(resourcesToTransform: Questionnaire
     assessmentSummary.responses.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
 
     return assessmentSummary;
-}
-
-function getAnswer(getAnswer: QuestionnaireResponseItem): MCCAssessmentResponseItem {
-  const answer = getAnswer.answer ? getAnswer.answer[0].valueCoding ? getAnswer.answer[0].valueCoding.display : getAnswer.answer[0].valueBoolean ? JSON.stringify(getAnswer.answer[0].valueBoolean) : getAnswer.answer[0].valueString ? getAnswer.answer[0].valueString : JSON.stringify(getAnswer.answer[0]) : '';
-  const response: MCCAssessmentResponseItem = {
-    question: getAnswer.text,
-    answer: answer
-  }
-  return response;
 }
 
 

--- a/src/app/core/lib/service-request/service-request.ts
+++ b/src/app/core/lib/service-request/service-request.ts
@@ -4,7 +4,7 @@ import Client from 'fhirclient/lib/Client';
 import { fhirclient } from 'fhirclient/lib/types';
 import { MccServiceRequestSummary } from '../../types/mcc-types';
 import { getCondition } from '../condition';
-import { fhirOptions, resourcesFrom, getSupplementalDataClient, displayConcept } from '../../utils/fhir';
+import { fhirOptions, resourcesFrom, getSupplementalDataClient, displayConcept, stripTrailingSlash } from '../../utils/fhir';
 
 import {
   transformToServiceRequest,
@@ -19,12 +19,13 @@ const getSupplementalData = async (launchURL: string, sdsClient: Client): Promis
     const linkages = await sdsClient.request('Linkage?item=Patient/' + sdsClient.patient.id);
 
     const urlSet = new Set();
-    urlSet.add(launchURL)
+    urlSet.add(stripTrailingSlash(launchURL))
     // Loop through second set of linkages
     for (const entry2 of linkages.entry) {
       for (const item2 of entry2.resource.item) {
-        if (item2.type === 'alternate' && !urlSet.has(item2.resource.extension[0].valueUrl)) {
-          urlSet.add(item2.resource.extension[0].valueUrl);
+        const alternateUrl = stripTrailingSlash(item2.resource.extension[0].valueUrl);
+        if (item2.type === 'alternate' && !urlSet.has(alternateUrl)) {
+          urlSet.add(alternateUrl);
 
           // Prepare FHIR request headers
           const fhirHeaderRequestOption = {} as fhirclient.RequestOptions;

--- a/src/app/core/utils/fhir.ts
+++ b/src/app/core/utils/fhir.ts
@@ -15,6 +15,10 @@ export const fhirOptions: fhirclient.FhirOptions = {
   pageLimit: 0,
 };
 
+// EHRs/SDS registrations are inconsistent about a trailing slash on FHIR base URLs;
+// strip it before comparing/deduping server URLs.
+export const stripTrailingSlash = (url: string): string => url?.replace(/\/+$/, '');
+
 export const notFoundResponse = (code?: string) => ({
   code,
   status: 'notfound',


### PR DESCRIPTION
- Reorganizes QuestionnaireMetadata to support multiple definitions for an assessment.
- Adds the Qualifacts PHQ-9 definition so it can be viewed alongside other PHQ-9s
- Fixes an issue with trailing slashes that was causing resource duplication in the new FHIR sandbox